### PR TITLE
Check fluid.hidden to not create extractor recipes for hidden fluids

### DIFF
--- a/src/data-final-fixes.lua
+++ b/src/data-final-fixes.lua
@@ -1,24 +1,24 @@
 require("config")
 
 for k,v in pairs(data.raw.fluid) do
-	data:extend(
-	{
+	if not v.hidden then
+		data:extend(
 		{
-			type = "recipe",
-			name = ("get-"..v.name),
-			icon = v.icon,
-			icon_size = v.icon_size,
-			category = CRAFTING_FLUID_CATEGORY_NAME,
-			--localised_name = {v.name},
-			energy_required = 1,
-			subgroup = "fill-barrel",
-			order = "b[fill-crude-oil-barrel]",
-			enabled = true,
-			ingredients = {},
-			results=
 			{
-				{type="fluid", name=v.name, amount=0}
+				type = "recipe",
+				name = ("get-"..v.name),
+				icons = v.icons or {{icon = v.icon, icon_size = v.icon_size}},
+				category = CRAFTING_FLUID_CATEGORY_NAME,
+				energy_required = 1,
+				subgroup = "fill-barrel",
+				order = "b[fill-crude-oil-barrel]",
+				enabled = true,
+				ingredients = {},
+				results=
+				{
+					{type="fluid", name=v.name, amount=0}
+				}
 			}
-		}
-	})
+		})
+	end
 end


### PR DESCRIPTION
... like "fluid-unknown".
Also use .icons to support modded fluids that may use that over .icon.