### PR TITLE
Rename repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,13 @@ Subspace Storage Factorio Mod
 
 **Warning:** this is a work in progress alpha and may not work as advertised.
 
-Allows storing items and fluid into a limitless subspace that is shared
-across the game world.  With Clusterio you can also share the subspace
-across a cluster of servers, enabling item and fluid production to be
-spread across multiple servers.
+Allows storing items and fluid into a limitless subspace that is shared across the game world.
+With Clusterio you can also share the subspace across a cluster of servers, enabling item and fluid production to be spread across multiple servers.
 
 
 Build Instructions
 ------------------
 
-Install Node.js version 10 or later and run `npm install` then run `node
-build`.  It will output the built mod into the `dist` folder by default.
+Install Node.js version 10 or later and run `npm install` then run `node build`.
+It will output the built mod into the `dist` folder by default.
 See `node build --help` for options.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Subspace Storage Factorio Mod
 
 **Warning:** this is a work in progress alpha and may not work as advertised.
 
-Allows storing items and fluid into a limitless subspace that is shared across the game world.
-With Clusterio you can also share the subspace across a cluster of servers, enabling item and fluid production to be spread across multiple servers.
+Allows storing items and fluid into a limitless subspace that is shared across servers via Clusterio.
+Currently requires Clusterio to work see [the repository and README for Clusterio](https://github.com/clusterio/clusterio) for instructions on setting it up.
 
 
 Build Instructions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subspace_storage",
-  "repository": "https://github.com/clusterio/factorioClusterioMod",
+  "repository": "https://github.com/clusterio/subspace_storage",
   "license": "MIT",
   "engines": {
     "node": ">=10"

--- a/src/info.json
+++ b/src/info.json
@@ -19,7 +19,7 @@
     ],
     "title": "Subspace Storage (Alpha)",
     "author": "Clusterio Team",
-    "homepage": "https://github.com/clusterio/factorioClusterio",
+    "homepage": "https://github.com/clusterio/subspace_storage",
     "description": "Allows storing items and fluids in a limitless shared subspace.  Warning: work in progress alpha.",
     "dependencies": [
         "base",


### PR DESCRIPTION
The Clusterio 2.0 mod is called subspace_storage and with 1.2.x being abandoned it's time to rename this repository to subspace_storage to reflect that and move the master branch forward to the subspace_storage version.