### PR TITLE
Prioritise virtual signals last in inventory combinator

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.99.15
+Date: ??. ??. ????
+  Bugfixes:
+    - Fixed inventory combinator outputting virtual signals named the same as item or fluid signals.
+---------------------------------------------------------------------------------------------------
 Version: 1.99.12
 Date: 09. 09. 2022
   Features:

--- a/src/control.lua
+++ b/src/control.lua
@@ -914,12 +914,12 @@ function UpdateInvCombinators()
 		for name, count in pairs(global.invdata) do
 			-- Combinator signals are limited to a max value of 2^31-1
 			count = math.min(count, 0x7fffffff)
-			if virtuals[name] then
-				invframe[#invframe+1] = {count=count,index=#invframe+1,signal={name=name,type="virtual"}}
+			if items[name] then
+				invframe[#invframe+1] = {count=count,index=#invframe+1,signal={name=name,type="item"}}
 			elseif fluids[name] then
 				invframe[#invframe+1] = {count=count,index=#invframe+1,signal={name=name,type="fluid"}}
-			elseif items[name] then
-				invframe[#invframe+1] = {count=count,index=#invframe+1,signal={name=name,type="item"}}
+			elseif virtuals[name] then
+				invframe[#invframe+1] = {count=count,index=#invframe+1,signal={name=name,type="virtual"}}
 			end
 		end
 	end

--- a/src/info.json
+++ b/src/info.json
@@ -2,17 +2,17 @@
     "name": "subspace_storage",
     "variants": [
         {
-            "version": "1.99.12",
+            "version": "1.99.15",
             "factorio_version": "0.17",
             "additional_files": { "compat.lua": ["compat", "factorio_0.17.lua"] }
         },
         {
-            "version": "1.99.13",
+            "version": "1.99.16",
             "factorio_version": "1.0",
             "additional_files": { "compat.lua": ["compat", "factorio_1.0.lua"] }
         },
         {
-            "version": "1.99.14",
+            "version": "1.99.17",
             "factorio_version": "1.1",
             "additional_files": { "compat.lua": ["compat", "factorio_1.1.lua"] }
         }


### PR DESCRIPTION
Some mods create virtual signals with the same name as items or fluids leading to the inventory combinator outputing the virtual signal instead of the correct item or fluid signal.  Move virtual signal test last to prioritise fluids and items with a given name first.