### PR TITLE
Remove icon prop from get fluid recipes

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,11 +1,13 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.99.18
-Date: ??. ??. ????
+Date: 09. 02. 2023
   Features:
     - Added Fluid Injectors can receive a circuit network signal of P = 1 to purge/void volumes lesser than 1.
+  Bugfixes:
+    - Fixed 'Key "icon_size" not found on property tree at ..." error that occurs with some mod combinations.
 ---------------------------------------------------------------------------------------------------
 Version: 1.99.15
-Date: ??. ??. ????
+Date: 16. 11. 2022
   Bugfixes:
     - Fixed inventory combinator outputting virtual signals named the same as item or fluid signals.
 ---------------------------------------------------------------------------------------------------

--- a/src/data-final-fixes.lua
+++ b/src/data-final-fixes.lua
@@ -7,7 +7,6 @@ for k,v in pairs(data.raw.fluid) do
 			{
 				type = "recipe",
 				name = ("get-"..v.name),
-				icons = v.icons or {{icon = v.icon, icon_size = v.icon_size}},
 				category = CRAFTING_FLUID_CATEGORY_NAME,
 				energy_required = 1,
 				subgroup = "fill-barrel",


### PR DESCRIPTION
The rules for icon, icons and icon_size are rather complicated to get right.  Remove them alltogether since these are optional and the default is to use the icon of the result.

Fixes the 'Key "icon_size" not found in property tree' error that occurs with some mod combination.