### PR TITLE
Keep Fluid Injector Empty

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.99.18
+Date: ??. ??. ????
+  Features:
+    - Added Fluid Injectors can receive a circuit network signal of P = 1 to purge/void volumes lesser than 1.
+---------------------------------------------------------------------------------------------------
 Version: 1.99.15
 Date: ??. ??. ????
   Bugfixes:

--- a/src/control.lua
+++ b/src/control.lua
@@ -564,26 +564,13 @@ function HandleInputTank(entityData)
 	if entity.valid then
 		--get the content of the chest
 		local fluid = fluidbox[1]
-		if fluid ~= nil and (fluid.amount) > 0 then
+		if fluid ~= nil and math.floor(fluid.amount) > 0 then
 			if isFluidLegal(fluid.name) then
-				if settings.global["subspace_storage-fluid-empty"].value then
-					if fluid.amount > 0 then
-						local fluid_taken = fluid.amount
-						AddItemToInputList(fluid.name, fluid_taken)
-						fluid.amount = fluid.amount - fluid_taken
-						if fluid.amount == 0 then
-							fluidbox[1] = nil
-						else
-							fluidbox[1] = fluid
-						end
-					end
-				else
-					if fluid.amount > 1 then
-						local fluid_taken = math.ceil(fluid.amount) - 1
-						AddItemToInputList(fluid.name, fluid_taken)
-						fluid.amount = fluid.amount - fluid_taken
-						fluidbox[1] = fluid
-					end
+				if fluid.amount > 1 then
+					local fluid_taken = math.ceil(fluid.amount) - 1
+					AddItemToInputList(fluid.name, fluid_taken)
+					fluid.amount = fluid.amount - fluid_taken
+					fluidbox[1] = fluid
 				end
 			end
 		end

--- a/src/control.lua
+++ b/src/control.lua
@@ -564,13 +564,17 @@ function HandleInputTank(entityData)
 	if entity.valid then
 		--get the content of the chest
 		local fluid = fluidbox[1]
-		if fluid ~= nil and math.floor(fluid.amount) > 0 then
+		if fluid ~= nil and fluid.amount > 0 then
 			if isFluidLegal(fluid.name) then
 				if fluid.amount > 1 then
 					local fluid_taken = math.ceil(fluid.amount) - 1
 					AddItemToInputList(fluid.name, fluid_taken)
 					fluid.amount = fluid.amount - fluid_taken
 					fluidbox[1] = fluid
+				else
+					if entity.get_merged_signal({name="signal-P",type="virtual"}) == 1 then
+						fluidbox[1] = nil
+					end
 				end
 			end
 		end

--- a/src/control.lua
+++ b/src/control.lua
@@ -564,13 +564,26 @@ function HandleInputTank(entityData)
 	if entity.valid then
 		--get the content of the chest
 		local fluid = fluidbox[1]
-		if fluid ~= nil and math.floor(fluid.amount) > 0 then
+		if fluid ~= nil and (fluid.amount) > 0 then
 			if isFluidLegal(fluid.name) then
-				if fluid.amount > 1 then
-					local fluid_taken = math.ceil(fluid.amount) - 1
-					AddItemToInputList(fluid.name, fluid_taken)
-					fluid.amount = fluid.amount - fluid_taken
-					fluidbox[1] = fluid
+				if settings.global["subspace_storage-fluid-empty"].value then
+					if fluid.amount > 0 then
+						local fluid_taken = fluid.amount
+						AddItemToInputList(fluid.name, fluid_taken)
+						fluid.amount = fluid.amount - fluid_taken
+						if fluid.amount == 0 then
+							fluidbox[1] = nil
+						else
+							fluidbox[1] = fluid
+						end
+					end
+				else
+					if fluid.amount > 1 then
+						local fluid_taken = math.ceil(fluid.amount) - 1
+						AddItemToInputList(fluid.name, fluid_taken)
+						fluid.amount = fluid.amount - fluid_taken
+						fluidbox[1] = fluid
+					end
 				end
 			end
 		end

--- a/src/info.json
+++ b/src/info.json
@@ -2,17 +2,17 @@
     "name": "subspace_storage",
     "variants": [
         {
-            "version": "1.99.15",
+            "version": "1.99.18",
             "factorio_version": "0.17",
             "additional_files": { "compat.lua": ["compat", "factorio_0.17.lua"] }
         },
         {
-            "version": "1.99.16",
+            "version": "1.99.19",
             "factorio_version": "1.0",
             "additional_files": { "compat.lua": ["compat", "factorio_1.0.lua"] }
         },
         {
-            "version": "1.99.17",
+            "version": "1.99.20",
             "factorio_version": "1.1",
             "additional_files": { "compat.lua": ["compat", "factorio_1.1.lua"] }
         }

--- a/src/locale/en/item-names.cfg
+++ b/src/locale/en/item-names.cfg
@@ -7,13 +7,11 @@ subspace_storage-zone-width=Restriction zone width
 subspace_storage-zone-height=Restriction zone height
 subspace_storage-max-electricity=Max electricity
 subspace_storage-infinity-mode=Infinity mode (cheat)
-subspace_storage-fluid-empty=Keep Fluid Injector Empty
 
 [mod-setting-description]
 subspace_storage-range-restriction-enabled=Restrict the area subspace injectors and extractors can be built in.
 subspace_storage-max-electricity=Stop exporting electricity after reaching this amount stored (set to -1 to disable limit)
 subspace_storage-infinity-mode=Make interactors cheat in resources instead of pulling from master storage (useful for testing in single player).
-subspace_storage-fluid-empty=Usually the Fluid Injector tries to keep a small amount of fluid on the Fluid Injector after exporting, if this true it doesn't
 
 [entity-name]
 subspace-item-injector=Item Injector

--- a/src/locale/en/item-names.cfg
+++ b/src/locale/en/item-names.cfg
@@ -22,6 +22,12 @@ subspace-resource-combinator=Subspace Inventory Combinator
 subspace-electricity-injector=Electricity Injector
 subspace-electricity-extractor=Electricity Extractor
 
+[item-description]
+subspace-fluid-injector=Can receive a circuit network signal of P = 1 to purge/void volumes lesser than 1.
+
+[entity-description]
+subspace-fluid-injector=Can receive a circuit network signal of P = 1 to purge/void volumes lesser than 1.
+
 [virtual-signal-name]
 signal-localid=Local World ID
 signal-unixtime=Unix timestamp

--- a/src/locale/en/item-names.cfg
+++ b/src/locale/en/item-names.cfg
@@ -7,11 +7,13 @@ subspace_storage-zone-width=Restriction zone width
 subspace_storage-zone-height=Restriction zone height
 subspace_storage-max-electricity=Max electricity
 subspace_storage-infinity-mode=Infinity mode (cheat)
+subspace_storage-fluid-empty=Keep Fluid Injector Empty
 
 [mod-setting-description]
 subspace_storage-range-restriction-enabled=Restrict the area subspace injectors and extractors can be built in.
 subspace_storage-max-electricity=Stop exporting electricity after reaching this amount stored (set to -1 to disable limit)
 subspace_storage-infinity-mode=Make interactors cheat in resources instead of pulling from master storage (useful for testing in single player).
+subspace_storage-fluid-empty=Usually the Fluid Injector tries to keep a small amount of fluid on the Fluid Injector after exporting, if this true it doesn't
 
 [entity-name]
 subspace-item-injector=Item Injector

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -38,11 +38,4 @@ data:extend {
 		order = "c1",
 		default_value = false,
 	},
-	{
-		type = "bool-setting",
-		name = "subspace_storage-fluid-empty",
-		setting_type = "runtime-global",
-		order = "d1",
-		default_value = false,
-	},
 }

--- a/src/settings.lua
+++ b/src/settings.lua
@@ -38,4 +38,11 @@ data:extend {
 		order = "c1",
 		default_value = false,
 	},
+	{
+		type = "bool-setting",
+		name = "subspace_storage-fluid-empty",
+		setting_type = "runtime-global",
+		order = "d1",
+		default_value = false,
+	},
 }


### PR DESCRIPTION
Tried to add a mod option to keep the fluid injector always empty. Usually it keeps a small amount of liquid, values between 0 and 1.

It's working for me, but only tested with Infinity mode (cheat).

I don't know if keeping some small amount of fluid on the fluid injector is intentional or not. If the fluid injector automatically gets empty every time, it would help me a lot to build an unloading train station for fluids to clusterio. 
 
It's possible to merge this, or something like this?